### PR TITLE
Docs closing tags

### DIFF
--- a/content/docs/templates/imageops/contents.lr
+++ b/content/docs/templates/imageops/contents.lr
@@ -51,7 +51,7 @@ Here an example that shows the camera information:
 ```html+jinja
 <div class="image">
   <img src="{{ image|url }}" alt="">
-  <p><strong>Camera:</strong> {{ image.exif.camera }}
+  <p><strong>Camera:</strong> {{ image.exif.camera }}</p>
 </div>
 ```
 

--- a/content/docs/templates/navigation/contents.lr
+++ b/content/docs/templates/navigation/contents.lr
@@ -71,7 +71,7 @@ the recursive Jinja loop system comes really in.
   {% set root = site.get('/') %}
   {% for child in root.children recursive %}
     <li{% if this._path == child._path %} class="active"{% endif
-        %}><a href="{{ child|url }}">{{ child.title }}</a>
+        %}><a href="{{ child|url }}">{{ child.title }}</a></li>
       {% if this.is_child_of(child) %}
       <ul>{{ loop(child.children) }}</ul>
       {% endif %}

--- a/content/docs/templates/urls/contents.lr
+++ b/content/docs/templates/urls/contents.lr
@@ -27,8 +27,8 @@ Because the path starts with a slash it will be treated as absolute path:
 
 ```html+jinja
 <ul class="nav">
-  <li><a href="{{ '/'|url }}">Index</a>
-  <li><a href="{{ '/about'|url }}">About</a>
+  <li><a href="{{ '/'|url }}">Index</a></li>
+  <li><a href="{{ '/about'|url }}">About</a></li>
 </ul>
 ```
 
@@ -59,7 +59,7 @@ link to all children of a page:
 ```html+jinja
 <ul class="nav">
 {% for page in this.children %}
-  <li><a href="{{ page|url }}">{{ page.title }}</a>
+  <li><a href="{{ page|url }}">{{ page.title }}</a></li>
 {% endfor %}
 </ul>
 ```


### PR DESCRIPTION
I'm very excited about the Lektor project! Thank you for making everything so clean and intuitive.

This is nitpicky, but I noticed in the templates documentation that a couple of the examples were missing closing tags. I figured this was a little thing I could do to help out.

Hope this helps!