### PR TITLE
Fixes typos and minor grammatical errors

### DIFF
--- a/content/docs/installation/contents.lr
+++ b/content/docs/installation/contents.lr
@@ -33,7 +33,7 @@ You need to make sure you have the following software installed on your computer
 * Python 2.7 (**not** Python 3.x, also `python-dev`, `libssl-dev` and
   `libffi-dev` is required on Ubuntu)
 * ImageMagick (`brew install imagemagick` can get you this on OS X and on
-  Ubuntu the `imagemagick` package needs ot be installed. On Windows do `choco
+  Ubuntu the `imagemagick` package needs to be installed. On Windows do `choco
   install imagemagick`, which requires [chocolatey :ext](https://chocolatey.org/),
   or [download from here :ext](http://www.imagemagick.org)).
 

--- a/content/docs/project/structure/contents.lr
+++ b/content/docs/project/structure/contents.lr
@@ -85,7 +85,7 @@ store things such as `favicon.ico`, `.htaccess` or similar things.
 
 The `flowblocks` folder contains models for blocks that are used by the
 [Flow System :ref](../../content/flow/).  Flow blocks split a part of a page into
-smaller pieces so that can be individually designed.  They work similar to models
+smaller pieces so those could be individually designed.  They work similar to models
 but are contained within a field of a model.
 
 ### `packages/`

--- a/content/docs/quickstart/contents.lr
+++ b/content/docs/quickstart/contents.lr
@@ -50,7 +50,7 @@ $ lektor server
 ```
 
 This will automatically start the server and you can navigate to
-[localhost:5000](http://localhost:5000/) open the project.
+[localhost:5000](http://localhost:5000/) to open the project.
 
 You can keep the server running, it will automatically rebuild your files as
 they change.
@@ -89,7 +89,7 @@ All your generated files will end up in that folder for easy publishing.
 ## Next Steps
 
 Now that you have done that, you might be interested in diving deeper into
-Lektor.  This might be good next steps:
+Lektor.  These might be good next steps:
 
 * The [Guides :ref](../guides/) which cover common setups.
 * The [Deployment Documentation :ref](../deployment/) which shows how to


### PR DESCRIPTION
Fixes typo on Installation guide.
Fixes minor grammatical errors on following files - 
  - Quickstart guide
  - Folder Structure documentation