### PR TITLE
datetime type and datetimeformat filter

### DIFF
--- a/content/docs/api/db/types/datetime/contents.lr
+++ b/content/docs/api/db/types/datetime/contents.lr
@@ -1,0 +1,59 @@
+title: datetime
+---
+type: type
+---
+summary: A type that can store a date and time.
+---
+body:
+
+The `datetime` type can store a date and time.
+`datetime` value can also include time zone info.
+
+The canonical format for the type in text form is `YYYY-MM-DD HH:MM:SS[ Z]`.
+
+`Z` is optional information.
+You can use `Z` field with below informations.
+
+* Time Zone Abbreviations such as `UTC`, `EST`
+* Time Zone Name such as `America/Dominica`
+* Timedelta such as `+0900`, `-0930`
+
+You can also use [datetimeformat
+:ref](../../../../api/templates/filters/datetimeformat/)
+filter with this type.
+
+## Valid Examples
+
+```
+pub_date: 2016-01-13 07:53:22
+
+or
+
+pub_date: 2016-01-13 07:53:22 UTC
+
+or
+
+pub_date: 2016-01-13 07:53:22 EST
+
+or
+
+pub_date: 2016-01-13 07:53:22 America/Dominica
+
+or
+
+pub_date: 2016-01-13 07:53:22 +0900
+```
+
+## Field Usage
+
+```ini
+[fields.pub_date]
+label = Publication date
+type = datetime
+```
+
+## Template Usage
+
+```html+jinja
+<p>Published: {{ this.pub_date.strftime('%Y-%m-%d %H:%M:%S') }}
+```

--- a/content/docs/api/templates/filters/datetimeformat/contents.lr
+++ b/content/docs/api/templates/filters/datetimeformat/contents.lr
@@ -1,0 +1,41 @@
+title: datetimeformat
+---
+type: filter
+---
+signature: datetime, format='medium', locale=None
+---
+summary: Formats a datetime into a string
+---
+body:
+
+To format a proper date (this is created by the [datetime
+:ref](../../../../api/db/types/datetime/) type) into a string this filter can
+be used.  It will automatically format based on the language used by the
+current context which is based on the locale of the current alt.
+
+A different language can be provided with the `locale` parameter.
+
+The following formats are locale specific:
+
+| Format   | How it Looks
+| -------- | ----------------
+| `full`   | Wednesday, January 13, 2016 at 7:08:35 AM GMT+00:00
+| `long`   | January 13, 2016 at 7:08:35 AM +0000
+| `medium` | Jan 13, 2016, 7:08:35 AM
+| `short`  | 1/13/16, 7:08 AM
+
+In addition to that format codes from the CLDR project can be used.  For
+more information see [CLDR Date/Time Symbols
+:ext](http://cldr.unicode.org/translation/date-time).
+
+## Examples
+
+```html+jinja
+<p>Date: {{ this.pub_date|datetimeformat('full') }}
+```
+
+Or with custom CLDR format strings:
+
+```html+jinja
+<p>Date: {{ this.pub_date|datetimeformat('yyyyy.MMMM.dd GGG hh:mm a') }}
+```


### PR DESCRIPTION
I think more information for datetime at start blog.

To beginner blogger, API docs is too far.
They must think "Why I can't save time info?"