### PR TITLE
Fixed a typo in the example

### DIFF
--- a/content/docs/api/db/types/html/contents.lr
+++ b/content/docs/api/db/types/html/contents.lr
@@ -17,7 +17,7 @@ It renders as a multi-line input field in the admin interface.
 [fields.tracking_code]
 label = Tracking Code
 description = raw HTML that is inserted for ad tracking purposes.
-type = text
+type = html
 ```
 
 ## Template Usage


### PR DESCRIPTION
It said `type = text` instead of `type = html`