### PR TITLE
Fix URL for download button

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -23,7 +23,7 @@ contents:
         Getting your ideas implemented is as easy as making breakfast eggs.
     </div>
     <div class="col-md-4 visible-md-block visible-lg-block">
-      <div class="download-btn"><a href="download/"
+      <div class="download-btn"><a href="downloads/"
         ><i class="glyphicon glyphicon-download-alt"></i> Download</a></div>
     </div>
   </div>


### PR DESCRIPTION
On the website when rate limiting is applied and link for latest version of lektor.app
cannot be retrieved, the fallback URL was Download/ and it should be Downloads/