### PR TITLE
Don't fail a PR if it isn't deployed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ install:
   - "pip install git+https://github.com/lektor/lektor#egg=Lektor"
 script:
   - "lektor build"
-  - "test \"$TRAVIS_PULL_REQUEST\" == \"false\" && test \"$TRAVIS_BRANCH\" == \"master\" && lektor deploy production || exit 0"
 cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/.cache/lektor/builds
+deploy:
+  provider: script
+  script: lektor deploy production
+  on:
+    branch: master
 addons:
   ssh_known_hosts: flow.srv.pocoo.org
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - "pip install git+https://github.com/lektor/lektor#egg=Lektor"
 script:
   - "lektor build"
-  - "test \"$TRAVIS_PULL_REQUEST\" == \"false\" && test \"$TRAVIS_BRANCH\" == \"master\" && lektor deploy production"
+  - "test \"$TRAVIS_PULL_REQUEST\" == \"false\" && test \"$TRAVIS_BRANCH\" == \"master\" && lektor deploy production || exit 0"
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
Every pull request to this repo has a failing build from Travis CI, which is misleading: Travis will fail the build if it doesn't deploy to production, and we don't *want* pull requests to deploy to production while they're being reviewed. This change makes Travis not treat this as a failure.