### PR TITLE
Document Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.5
 install:
   - "pip install -U pip"
   - "pip install git+https://github.com/lektor/lektor#egg=Lektor"

--- a/assets/install.ps1
+++ b/assets/install.ps1
@@ -23,15 +23,19 @@ LRESULT = LPARAM
 HWND_BROADCAST = 0xFFFF
 WM_SETTINGCHANGE = 0x1A
 
+PY2 = sys.version_info[0] == 2
+if PY2:
+    input = raw_input
+
 
 def get_confirmation():
     while 1:
-        input = raw_input('Continue? [Yn] ').lower().strip()
-        if input in ('', 'y'):
+        user_input = input('Continue? [Yn] ').lower().strip()
+        if user_input in ('', 'y'):
             break
-        elif input == 'n':
-            print
-            print 'Aborted!'
+        elif user_input == 'n':
+            print()
+            print('Aborted!')
             sys.exit()
 
 def find_location():
@@ -39,9 +43,9 @@ def find_location():
     return install_dir, os.path.join(install_dir, LIB)
 
 def deletion_error(func, path, excinfo):
-    print 'Problem deleting {}'.format(path)
-    print 'Please try and delete {} manually'.format(path)
-    print 'Aborted!'
+    print('Problem deleting {}'.format(path))
+    print('Please try and delete {} manually'.format(path))
+    print('Aborted!')
     sys.exit()
 
 def wipe_installation(install_dir):
@@ -49,16 +53,16 @@ def wipe_installation(install_dir):
 
 def check_installation(install_dir):
     if os.path.exists(install_dir):
-        print '   Lektor seems to be installed already.'
-        print '   Continuing will delete:'
-        print '   %s' % install_dir
-        print
+        print('   Lektor seems to be installed already.')
+        print('   Continuing will delete:')
+        print('   %s' % install_dir)
+        print()
         get_confirmation()
-        print
+        print()
         wipe_installation(install_dir)
 
 def fail(message):
-    print 'Error: %s' % message
+    print('Error: %s' % message)
     sys.exit(1)
 
 def add_to_path(location):
@@ -108,19 +112,19 @@ def install(virtualenv_url, virtualenv_filename, install_dir, lib_dir):
 
 
 def main():
-    print
-    print 'Welcome to Lektor'
-    print
-    print 'This script will install Lektor on your computer.'
-    print
+    print()
+    print('Welcome to Lektor')
+    print()
+    print('This script will install Lektor on your computer.')
+    print()
 
     install_dir, lib_dir = find_location()
 
     check_installation(install_dir)
 
-    print '   Installing at:'
-    print '   %s' % install_dir
-    print
+    print('   Installing at:')
+    print('   %s' % install_dir)
+    print()
     get_confirmation()
 
     for url in json.load(urllib.urlopen(VENV_URL))['urls']:
@@ -134,8 +138,8 @@ def main():
 
     install(virtualenv_url, virtualenv_filename, install_dir, lib_dir)
 
-    print
-    print 'All done!'
+    print()
+    print('All done!')
 
 main()
 "@

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -11,16 +11,12 @@
 I() {
   set -u
 
-  if hash python2 2> /dev/null; then
-    PY=python2
-  elif hash python 2> /dev/null; then
-    PY=python
-  else
+  if ! hash python 2> /dev/null; then
     echo "Error: To use this script you need to have Python installed"
     exit 1
   fi
 
-  $PY - <<'EOF'
+  python - <<'EOF'
 if 1:
 
     import os
@@ -30,6 +26,10 @@ if 1:
     import tempfile
     import shutil
     from subprocess import Popen
+
+    PY2 = sys.version_info[0] == 2
+    if PY2:
+        input = raw_input
 
     sys.stdin = open('/dev/tty', 'r')
 
@@ -66,18 +66,18 @@ if 1:
 
     def get_confirmation():
         while 1:
-            input = raw_input('Continue? [Yn] ').lower().strip()
-            if input in ('', 'y'):
+            user_input = input('Continue? [Yn] ').lower().strip()
+            if user_input in ('', 'y'):
                 break
-            elif input == 'n':
-                print
-                print 'Aborted!'
+            elif user_input == 'n':
+                print()
+                print('Aborted!')
                 sys.exit()
 
     def deletion_error(func, path, excinfo):
-        print 'Problem deleting {}'.format(path)
-        print 'Please try and delete {} manually'.format(path)
-        print 'Aborted!'
+        print('Problem deleting {}'.format(path))
+        print('Please try and delete {} manually'.format(path))
+        print('Aborted!')
         sys.exit()
 
     def wipe_installation(lib_dir, symlink_path):
@@ -89,18 +89,18 @@ if 1:
     def check_installation(lib_dir, bin_dir):
         symlink_path = os.path.join(bin_dir, 'lektor')
         if os.path.exists(lib_dir) or os.path.lexists(symlink_path):
-            print '   Lektor seems to be installed already.'
-            print '   Continuing will delete:'
-            print '   %s' % lib_dir
-            print '   and remove this symlink:'
-            print '   %s' % symlink_path
-            print
+            print('   Lektor seems to be installed already.')
+            print('   Continuing will delete:')
+            print('   %s' % lib_dir)
+            print('   and remove this symlink:')
+            print('   %s' % symlink_path)
+            print()
             get_confirmation()
-            print
+            print()
             wipe_installation(lib_dir, symlink_path)
 
     def fail(message):
-        print 'Error: %s' % message
+        print('Error: %s' % message)
         sys.exit(1)
 
     def install(virtualenv_url, lib_dir, bin_dir):
@@ -119,11 +119,11 @@ if 1:
                    os.path.join(bin_dir, 'lektor'))
 
     def main():
-        print
-        print 'Welcome to Lektor'
-        print
-        print 'This script will install Lektor on your computer.'
-        print
+        print()
+        print('Welcome to Lektor')
+        print()
+        print('This script will install Lektor on your computer.')
+        print()
 
         paths = find_user_paths()
         if not paths:
@@ -136,10 +136,10 @@ if 1:
 
         check_installation(lib_dir, bin_dir)
 
-        print 'Installing at:'
-        print '  bin: %s' % bin_dir
-        print '  app: %s' % lib_dir
-        print
+        print('Installing at:')
+        print('  bin: %s' % bin_dir)
+        print('  app: %s' % lib_dir)
+        print()
 
         get_confirmation()
 
@@ -152,8 +152,8 @@ if 1:
 
         install(virtualenv, lib_dir, bin_dir)
 
-        print
-        print 'All done!'
+        print()
+        print('All done!')
 
     main()
 EOF

--- a/content/docs/api/build/context/contents.lr
+++ b/content/docs/api/build/context/contents.lr
@@ -25,5 +25,5 @@ the return value will be `None`.
 from lektor.context import get_ctx
 
 ctx = get_ctx()
-print 'The current source is %s' % ctx.source
+print('The current source is %s' % ctx.source)
 ```

--- a/content/docs/api/build/context/gather-dependencies/contents.lr
+++ b/content/docs/api/build/context/gather-dependencies/contents.lr
@@ -21,5 +21,5 @@ encounters a dependency it will invoke the passed function.
 deps = set()
 with get_ctx().gather_dependencies(deps.add):
     items = pad.query('/path/to/some/pages').all()
-print 'The dependencies are: %s' % deps
+print('The dependencies are: %s' % deps)
 ```

--- a/content/docs/api/db/record/getitem/contents.lr
+++ b/content/docs/api/db/record/getitem/contents.lr
@@ -18,5 +18,5 @@ as system fields which are prefixed by an underscore).
 
 ```python
 for child in this.children:
-    print 'ID: %s' % child['_id']
+    print('ID: %s' % child['_id'])
 ```

--- a/content/docs/api/plugins/events/before-build/contents.lr
+++ b/content/docs/api/plugins/events/before-build/contents.lr
@@ -31,5 +31,5 @@ in future versions.
 
 ```python
 def on_before_build(self, source, prog, **extra):
-    print 'building %s' % source.source_filename
+    print('building %s' % source.source_filename)
 ```

--- a/content/docs/api/plugins/plugin/emit/contents.lr
+++ b/content/docs/api/plugins/plugin/emit/contents.lr
@@ -32,7 +32,7 @@ from lektor.pluginsystem import Plugin
 class MyPlugin(Plugin):
 
     def on_my_plugin_setup(self, foo, **extra):
-        print 'got %s' % foo
+        print('got %s' % foo)
 ```
 
 (This assumes the plugin id is set to `my-plugin` in `setup.py`)

--- a/content/docs/deployment/glpages/contents.lr
+++ b/content/docs/deployment/glpages/contents.lr
@@ -32,7 +32,7 @@ To enable support for Lektor you need to create a `.gitlab-ci.yml` config
 next to your `.lektorproject` file with the following contents:
 
 ```yaml
-image: python:2.7
+image: python:latest
 
 pages:
   script:

--- a/content/docs/deployment/travisci/contents.lr
+++ b/content/docs/deployment/travisci/contents.lr
@@ -28,7 +28,7 @@ file into your repository.  You can copy paste this over:
 
 ```yaml
 language: python
-python: 2.7
+python: 3.5
 install: "pip install Lektor"
 script: "lektor build"
 deploy:
@@ -119,7 +119,7 @@ caching.  Adjust your `.travis.yml` file to look like this:
 
 ```yaml
 language: python
-python: 2.7
+python: 3.5
 cache:
   directories:
     - $HOME/.cache/pip
@@ -139,7 +139,7 @@ config:
 
 ```yaml
 language: python
-python: 2.7
+python: 3.5
 cache:
   directories:
     - $HOME/.cache/pip

--- a/content/docs/installation/contents.lr
+++ b/content/docs/installation/contents.lr
@@ -30,7 +30,7 @@ the installation is a bit more involved.
 
 You need to make sure you have the following software installed on your computer:
 
-* Python 2.7 (**not** Python 3.x, also `python-dev`, `libssl-dev` and
+* Python 2.7 or above (also `python-dev`, `libssl-dev` and
   `libffi-dev` is required on Ubuntu)
 * ImageMagick (`brew install imagemagick` can get you this on OS X and on
   Ubuntu the `imagemagick` package needs to be installed. On Windows do `choco


### PR DESCRIPTION
Now that [Lektor supports Python 3](https://github.com/lektor/lektor/pull/207), we need to document this support. This change is perhaps a bit extreme: it replaces all explicit references to Python 2.7 with explicit references to Python 3.5. However, it's a good start, and it can and should be reviewed before being merged.

@mitsuhiko, can you review this please? Also, what is the best way to indicate that Lektor only supports Python 3 in version 3 and onwards?
