### PR TITLE
Update documentation to fit to #240

### DIFF
--- a/content/docs/deployment/travisci/contents.lr
+++ b/content/docs/deployment/travisci/contents.lr
@@ -45,7 +45,7 @@ in the project file would be to use `ghpages+https` like this:
 
 ```ini
 [servers.ghpages]
-target = ghpages+https://username/repository
+target = ghpages+https://username/repository.git
 ```
 
 You need to add this to your `.lektorproject` file.


### PR DESCRIPTION
In #240 we talk about adding .git at the end of the target

example

```
[servers.ghpages]
target = ghpages+https://enguerran/Agence-Tous-Risques.git
```

And the documentation seems not to be updated since. Here is the fix.
