### PR TITLE
Add name and version fields to package.json in webpack guide

### DIFF
--- a/content/docs/guides/webpack/contents.lr
+++ b/content/docs/guides/webpack/contents.lr
@@ -44,7 +44,11 @@ $ npm init
 ```
 
 This will ask you a bunch of questions (invoke with ``--yes`` to use default
-values) and then generate the file for you:
+values) and then generate a ``package.json`` file for you.
+
+It should look similar to the following example. Please **do not** just
+copy-paste this! Instead run the tool, so that your ``package.json`` meets
+the latest format specification.
 
 ```json
 {

--- a/content/docs/guides/webpack/contents.lr
+++ b/content/docs/guides/webpack/contents.lr
@@ -37,8 +37,14 @@ Now you need to configure webpack.  The plugin expects a webpack project in the
 This file instructs `npm` which packages we will need.  All we need for a
 start is to create an almost empty file:
 
+Recent versions of `npm` require `name` and `version` fields in your
+`package.json` (see [npm package.json docs
+:ext](https://docs.npmjs.com/files/package.json)).
+
 ```json
 {
+  "name": "foobar",
+  "version": "0.1.0",
   "private": true
 }
 ```

--- a/content/docs/guides/webpack/contents.lr
+++ b/content/docs/guides/webpack/contents.lr
@@ -34,18 +34,29 @@ Now you need to configure webpack.  The plugin expects a webpack project in the
 
 ### `package.json`
 
-This file instructs `npm` which packages we will need.  All we need for a
-start is to create an almost empty file:
+This file instructs `npm` which packages we will need.
 
-Recent versions of `npm` require `name` and `version` fields in your
-`package.json` (see [npm package.json docs
-:ext](https://docs.npmjs.com/files/package.json)).
+[npm-init :ext](https://docs.npmjs.com/cli/init) is a command-line tool to
+interactively create a ``package.json`` file.
+
+```
+$ npm init
+```
+
+This will ask you a bunch of questions (invoke with ``--yes`` to use default
+values) and then generate the file for you:
 
 ```json
 {
-  "name": "foobar",
+  "name": "lektor-example",
   "version": "0.1.0",
-  "private": true
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
 }
 ```
 


### PR DESCRIPTION
Hey there! 👋 

I've run into issues when trying to run ``$ lektor server -f webpack``. It kept complaining about not being able to find ``name`` and ``version`` in package.json.

I've added these fields to my config and seemed to resolve the problem.

Please let me know your thoughts! Thank you for making Lektor! 👍 