### PR TITLE
Fix typos errors in model docs

### DIFF
--- a/content/docs/models/contents.lr
+++ b/content/docs/models/contents.lr
@@ -36,13 +36,13 @@ label = Body
 type = markdown
 ```
 
-In this particular case we have a model with the id `model` (as defined by the
+In this particular case, we have a model with the id `page` (as defined by the
 filename) and a name `Page` which will appear like that in the UI.  Pages that
 use this model will use the template expression `{{ this.title }}` to be
-displayed in the UI.  In this case it uses the title of the page.
+displayed in the UI.  In this case, it uses the title of the page.
 
 There are two fields defined: a `title` and a `body`.  The former is just an
-unformatted string which is show larger in the UI (`size = large`) and the
+unformatted string which is shown larger in the UI (`size = large`) and the
 latter uses markdown for rendering.  This will give it a text area in the admin
 panel.
 
@@ -62,8 +62,8 @@ The following options are used for all types:
 - `description`: an optional string that provides some description for the
   field that is shown in the UI to give a bit more explanation.
 - `addon_label`: an optional string that is supported by all types that are
-  rendered as an input field.  This string is shown as a UI label on the
-  right side of the input field to give it more context.  For instance it can
+  rendered as an input field.  This string is shown as an UI label on the 
+right side of the input field to give it more context.  For instance, it can
   be used to clarify units of a field (pixel, percent etc.).
 - `width`: defines the width of the input in the admin as a fraction.  For
   instance `1/4` sets it to a quarter of the width, `1/2` to a half etc.


### PR DESCRIPTION
Just a simple typo fix that I noticed while reading the documentation.
And Grammarly has shown me few more typos so I fixed them too (I am not a Grammar Nazi).