### PR TITLE
Upgrade webpack example in documentation to webpack v2

### DIFF
--- a/content/docs/guides/webpack/contents.lr
+++ b/content/docs/guides/webpack/contents.lr
@@ -107,25 +107,28 @@ module.exports = {
   },
   devtool: '#cheap-module-source-map',
   resolve: {
-    modulesDirectories: ['node_modules'],
-    extensions: ['', '.js']
+    modules: ['node_modules'],
+    extensions: ['.js']
   },
   module: {
-    loaders: [
+    rules: [
       { test: /\.js$/, exclude: /node_modules/,
         loader: 'babel-loader' },
       { test: /\.scss$/,
-        loader: ExtractTextPlugin.extract(
-          'style-loader', 'css-loader!sass-loader') },
+        loader: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader!sass-loader' } ) },
       { test: /\.css$/,
-        loader: ExtractTextPlugin.extract(
-          'style-loader', 'css-loader') },
+        loader: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: 'css-loader' } ) },
       { test: /\.(woff2?|ttf|eot|svg|png|jpe?g|gif)$/,
         loader: 'file' }
     ]
   },
   plugins: [
-    new ExtractTextPlugin('styles.css', {
+    new ExtractTextPlugin({
+      filename: 'styles.css',
       allChunks: true
     }),
     new webpack.optimize.UglifyJsPlugin()


### PR DESCRIPTION
See:
- https://webpack.js.org/guides/migrating
- http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/
- https://github.com/webpack/webpack/issues/3043