### PR TITLE
Encoding issue with parsing response from https://pypi.python.org/pypi/virtualenv/json

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -146,7 +146,7 @@ if 1:
 
         get_confirmation()
 
-        for url in json.load(urlopen(VENV_URL))['urls']:
+        for url in json.loads(urlopen(VENV_URL).read().decode('utf-8'))['urls']:
             if url['python_version'] == 'source':
                 virtualenv = url['url']
                 break


### PR DESCRIPTION
Fix to avoid "TypeError: the JSON object must be str, not 'bytes'" error while installing.

Traceback:
curl -sf https://www.getlektor.com/install.sh | sudo sh

Welcome to Lektor

This script will install Lektor on your computer.

Installing at:
  bin: /usr/local/bin
  app: /usr/local/lib/lektor

Continue? [Yn] y
Traceback (most recent call last):
  File "<stdin>", line 142, in <module>
  File "<stdin>", line 130, in main
  File "/usr/lib/python3.5/json/__init__.py", line 268, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'