### PR TITLE
Fixed query in single page example.

### DIFF
--- a/content/docs/guides/single-page/contents.lr
+++ b/content/docs/guides/single-page/contents.lr
@@ -108,7 +108,7 @@ need to query for all the other pages we have below `doc/`:
 {% extends "layout.html" %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block body %}
-  {% set pages = site.query('/doc').all() %}
+  {% set pages = site.query('/doc').include_undiscoverable(true).all() %}
   <header>
     <h1>{{ this.title }}</h1>
     <nav>


### PR DESCRIPTION
I couldn't get the example to work without adding `.include_undiscoverable(true)`.