### PR TITLE
Moving plugins into sections

### DIFF
--- a/content/docs/plugins/list/contents.lr
+++ b/content/docs/plugins/list/contents.lr
@@ -4,58 +4,60 @@ summary: A list of known plugins.
 ---
 body:
 
-Lektor is a very young project so naturally not that many plugins exist yet.
-This is a list of currently known plugins.
+Lektor is a young project but it has a growing list of both official and community supported plugins.
+Official plugins were developed by the authors of Lektor and kept in good shape together with the rest of the
+project. Community plugins are moderated and updated regularly, but 
+they might not keep pace with development on Lektor.
+They are maintained by the community.
 
-## Official
+This is a list of currently known plugins. Official plugins are prefixed with as asterisk (*) and are listed first in each section and separated by an underline.
 
-These are official plugins which means that they were developed by the
-authors of Lektor and kept in good shape together with the rest of the
-project:
+## Build
 
-* [disqus-comments :ext](https://github.com/lektor/lektor-disqus-comments):
-  this plugin embeds disqus comments into your website.
-* [webpack-support :ext](https://github.com/lektor/lektor-webpack-support):
+* *[webpack-support :ext](https://github.com/lektor/lektor-webpack-support):
   adds support for building websites with webpack.
-* [markdown-highlighter :ext](https://github.com/lektor/lektor-markdown-highlighter):
-  adds support for syntax highlighting to markdown code snippets.
-* [markdown-header-anchors :ext](https://github.com/lektor/lektor-markdown-header-anchors):
-  adds support for header anchors and table of contents to Markdown.
-* [markdown-admonition :ext](https://github.com/lektor/lektor-markdown-admonition):
-  adds admonition block support to Markdown.
-
-## Unofficial
-
-These are unofficial plugins. This list is moderated and updated
-regularly, but they still aren't developed by the authors of Lektor,
-so they might not keep pace with development on Lektor.
-
-* [s3 :ext](https://github.com/spenczar/lektor-s3):
-  allows deployment of websites to S3 buckets
-* [markdown-excerpt :ext](https://github.com/bancek/lektor-markdown-excerpt):
-  adds filter for Markdown body excerpt
-* [github-repos :ext](https://github.com/marksteve/lektor-github-repos):
-  fetches your GitHub repos for display in Lektor templates
-* [google-analytics :ext](https://github.com/kmonsoor/lektor-google-analytics): Adds `Google Analytics` support to Lektor-generated site.
-* [yandex-metrica :ext](https://github.com/gagoman/lektor-yandex-metrica): Adds `Yandex Metrica` support to Lektor-generated site.
-* [atom :ext](https://github.com/dwt/lektor-atom): Generate Atom feeds for your content.
-* [surge :ext](https://github.com/ajdavis/lektor-surge): Publish your site to [Surge](https://surge.sh/).
-* [netlify :ext](https://github.com/ajdavis/lektor-netlify): Publish your site to [Netlify](https://www.netlify.com/).
-* [tags :ext](https://github.com/ajdavis/lektor-tags): For each tag on site, build a list of pages with that tag.
-* [i18n :ext](https://github.com/numericube/lektor-i18n-plugin): Use GetText .PO files to translate your site **content**.
+___
 * [htmlmin :ext](https://github.com/vesuvium/lektor-htmlmin): Automatically minifies .html files in build directory
-* [creative-commons :ext](https://github.com/humrochagf/lektor-creative-commons): Add Creative Commons license to your pages
-* [nofollow :ext](https://github.com/yargies/lektor-nofollow): Easily create nofollow links in markdown
-* [minify :ext](https://github.com/pietroalbini/lektor-minify): Minify changed files automatically during the build
-* [asciidoc :ext](https://github.com/ajdavis/lektor-asciidoc/): Add asciidoc field type
-* [shortcodes :ext](https://github.com/skorokithakis/lektor-shortcodes): A plugin allowing you to use shortcodes (something like tags) in your model fields
-* [thumbnail-generator :ext](https://github.com/skorokithakis/lektor-thumbnail-generator): A plugin allowing you to generate configurable thumbnails for all your attachment images, so you can link them in your posts
-* [rst :ext](https://github.com/fschulze/lektor-rst): A [reStructuredText](http://docutils.sourceforge.net) plugin
+* [i18n :ext](https://github.com/numericube/lektor-i18n-plugin): Use GetText .PO files to translate your site **content**.
 * [make :ext](https://github.com/BarnabyShearer/lektor-make): Run `make lektor` for custom build systems
+* [minify :ext](https://github.com/pietroalbini/lektor-minify): Minify changed files automatically during the build
+
+## Content
+
+* *[markdown-admonition :ext](https://github.com/lektor/lektor-markdown-admonition):
+  adds admonition block support to Markdown.
+* *[markdown-header-anchors :ext](https://github.com/lektor/lektor-markdown-header-anchors):
+  adds support for header anchors and table of contents to Markdown.
+* *[markdown-highlighter :ext](https://github.com/lektor/lektor-markdown-highlighter):
+  adds support for syntax highlighting to markdown code snippets.
+___
+* [asciidoc :ext](https://github.com/ajdavis/lektor-asciidoc/): Add asciidoc field type
 * [jinja-content :ext](https://github.com/terminal-labs/lektor-jinja-content) Enable Jinja with the [Template Context](https://www.getlektor.com/docs/templates/#template-context) in your content fields, e.g. combining Jinja and Markdown.
-* [slugify :ext](https://github.com/terminal-labs/lektor-slugify) Add a Jinja filter to slugify unicode.
+* [nofollow :ext](https://github.com/yargies/lektor-nofollow): Easily create nofollow links in markdown
+* [rst :ext](https://github.com/fschulze/lektor-rst): A [reStructuredText](http://docutils.sourceforge.net) plugin
+* [tags :ext](https://github.com/ajdavis/lektor-tags): For each tag on site, build a list of pages with that tag.
+
+## Deploy
+
+* [netlify :ext](https://github.com/ajdavis/lektor-netlify): Publish to [Netlify](https://www.netlify.com/).
+* [s3 :ext](https://github.com/spenczar/lektor-s3): Publish to [S3](https://aws.amazon.com/s3/) buckets and [Cloudfront](https://aws.amazon.com/cloudfront/).
+* [surge :ext](https://github.com/ajdavis/lektor-surge): Publish to [Surge](https://surge.sh/).
+
+## Templates
+
+* *[disqus-comments :ext](https://github.com/lektor/lektor-disqus-comments):  Embed Disqus comments into your website. 
+___
+* [atom :ext](https://github.com/dwt/lektor-atom): Generate Atom feeds for your content.
+* [creative-commons :ext](https://github.com/humrochagf/lektor-creative-commons): Add Creative Commons license to your pages.
+* [github-repos :ext](https://github.com/marksteve/lektor-github-repos):  Fetches your GitHub repos for display in Lektor templates.
+* [markdown-excerpt :ext](https://github.com/bancek/lektor-markdown-excerpt):  Adds filter for Markdown body excerpt.
+* [google-analytics :ext](https://github.com/kmonsoor/lektor-google-analytics): Adds `Google Analytics` support to Lektor-generated site.
+* [shortcodes :ext](https://github.com/skorokithakis/lektor-shortcodes): Allows you to use shortcodes (something like tags) in your model fields.
+* [slugify :ext](https://github.com/terminal-labs/lektor-slugify) Add a Jinja filter to slugify strings, even Unicode.
 * [natural-language :ext](https://github.com/terminal-labs/lektor-natural-language) Add filters to do basic natural language processing with NLTK. Find keywords and sentence structure naturally.
 * [strip-html-tags :ext](https://github.com/terminal-labs/lektor-strip-html-tags) Add a filter to transform HTML into simple text by stripping HTML tags.
+* [thumbnail-generator :ext](https://github.com/skorokithakis/lektor-thumbnail-generator): Allows you to generate configurable thumbnails for all your attachment images, so you can link them in your pages.
+* [yandex-metrica :ext](https://github.com/gagoman/lektor-yandex-metrica): Adds `Yandex Metrica` support to Lektor-generated site.
 
 ! Have your own plugin and you want to see it here?  Just [edit this page
 on GitHub :ref](https://github.com/lektor/lektor-website/edit/master/content/docs/plugins/list/contents.lr),


### PR DESCRIPTION
resolves #182

![pluginslist2](https://user-images.githubusercontent.com/3431410/38970686-7fb6a04a-435c-11e8-8bd1-6d0724c6c304.png)
![pluginslist1](https://user-images.githubusercontent.com/3431410/38970687-7fcaff4a-435c-11e8-8345-eb56f41f3929.png)



I suggest trying out the branch pluginslist-update id you'd like to see it laid out in a pretty way :)

I moved them into sections I think make sense, and tried to keep the official ones distinguishable. Each subsection is also sorted alphabetically.

This does not included any tagging or fancier categorization. It is meant to be rough, yet better than what we have right now.

@lektor/developers ?