### PR TITLE
Sitemap template code fix in Lektor documentation

### DIFF
--- a/content/docs/guides/sitemap/contents.lr
+++ b/content/docs/guides/sitemap/contents.lr
@@ -60,7 +60,7 @@ create a `sitemap/contents.lr` file instead and use a template like
 {% block title %}Sitemap{% endblock %}
 {% block body %}
 <ul class="sitemap">
-  {% for page in [site.root] recursive if page.record_label %}
+  {% for page in [site.root] if page.record_label recursive %}
   <li><a href="{{ page|url }}">{{ page.record_label }}</a>
     {% if page.children %}
       <ul>{{ loop(page.children) }}</ul>


### PR DESCRIPTION
The code for human-readable sitemap template in documentation doesn't work. Proposing a fix that was suggested in one of the comments and works.