### PR TITLE
[missing-events] Document the rest of the Lektor plugin events.

### DIFF
--- a/content/docs/api/plugins/events/after-prune/contents.lr
+++ b/content/docs/api/plugins/events/after-prune/contents.lr
@@ -1,0 +1,9 @@
+title: after-prune
+---
+body: This event is emitted after before Lektor searches the build directory for data that does not match a known artifact, and removes that data. This event is also emitted after a `clean`, that is, when the build directory is completely purged of all data.
+---
+signature: builder, all
+---
+summary: This event is emitted after unused data in the build folder is removed.
+---
+type: event

--- a/content/docs/api/plugins/events/before-prune/contents.lr
+++ b/content/docs/api/plugins/events/before-prune/contents.lr
@@ -1,0 +1,9 @@
+title: before-prune
+---
+body: This event is emitted right before Lektor searches the build directory for data that does not match a known artifact. Orphaned data is then removed. This event is also emitted before a `clean`, that is, when the build directory is completely purged of all data.
+---
+signature: builder, all
+---
+summary: This event is emitted before unused data in the build folder is removed.
+---
+type: event

--- a/content/docs/api/plugins/events/markdown-config/contents.lr
+++ b/content/docs/api/plugins/events/markdown-config/contents.lr
@@ -1,0 +1,30 @@
+title: markdown-config
+---
+body:
+
+! Future versions of Lektor may change its Markdown parser away from [Mistune](https://github.com/lepture/mistune), and the various markdown related event hooks may be completely removed or work differently if that happens.
+
+This event is emitted right after MarkdownConfig is instantiated, in which configuration can be set. This is done before the renderer is made.
+
+## Example
+
+[lektor-markdown-header-anchors :ext](https://github.com/lektor/lektor-markdown-header-anchors) uses this to register a renderer mixin:
+
+```python
+def on_markdown_config(self, config, **extra):
+    class HeaderAnchorMixin(object):
+        def header(renderer, text, level, raw):
+            if self.get_config().get('anchor-type') == "random":
+                anchor = uuid.uuid4().hex[:6]
+            else:
+                anchor = slugify(raw)
+            renderer.meta['toc'].append((level, anchor, Markup(text)))
+            return '<h%d id="%s">%s</h%d>' % (level, anchor, text, level)
+    config.renderer_mixins.append(HeaderAnchorMixin)
+```
+---
+signature: config
+---
+summary: This event is emitted while the Markdown renderer is configured.
+---
+type: event

--- a/content/docs/api/plugins/events/markdown-lexer-config/contents.lr
+++ b/content/docs/api/plugins/events/markdown-lexer-config/contents.lr
@@ -1,0 +1,17 @@
+title: markdown-lexer-config
+---
+module: 
+---
+type: event
+---
+signature: config, renderer
+---
+summary: This event is emitted after the renderer is made, but before it is used.
+---
+body:
+
+! Future versions of Lektor may change its Markdown parser away from [Mistune](https://github.com/lepture/mistune), and the various markdown related event hooks may be completely removed or work differently if that happens.
+
+This event is emitted right after markdown renderer is made, but before it is used to render markdown. This is where lexer configuration can be set.
+---
+version_added: 3.1

--- a/content/docs/api/plugins/events/markdown-meta-init/contents.lr
+++ b/content/docs/api/plugins/events/markdown-meta-init/contents.lr
@@ -1,0 +1,22 @@
+title: markdown-meta-init
+---
+body:
+
+! Future versions of Lektor may change its Markdown parser away from [Mistune](https://github.com/lepture/mistune), and the various markdown related event hooks may be completely removed or work differently if that happens.
+
+This event is emitted before the markdown meta information is set. This can be used to add custom meta variables to the markdown object.
+
+## Example
+
+[lektor-markdown-header-anchors :ext](https://github.com/lektor/lektor-markdown-header-anchors) uses this to initialize a meta var as an empty list:
+
+```python
+def on_markdown_meta_init(self, meta, **extra):
+    meta['toc'] = []
+```
+---
+signature: meta, record
+---
+summary: This event is emitted before the markdown meta information is set.
+---
+type: event

--- a/content/docs/api/plugins/events/markdown-meta-postprocess/contents.lr
+++ b/content/docs/api/plugins/events/markdown-meta-postprocess/contents.lr
@@ -1,0 +1,39 @@
+title: markdown-meta-postprocess
+---
+body:
+
+! Future versions of Lektor may change its Markdown parser away from [Mistune](https://github.com/lepture/mistune), and the various markdown related event hooks may be completely removed or work differently if that happens.
+
+This event is emitted after the markdown has been rendered. This can be used to change the markdown object meta information after the fact.
+
+## Example
+
+[lektor-markdown-header-anchors :ext](https://github.com/lektor/lektor-markdown-header-anchors) uses this to populate a meta var:
+
+```python
+def on_markdown_meta_postprocess(self, meta, **extra):
+    prev_level = None
+    toc = []
+    stack = [toc]
+
+    for level, anchor, title in meta['toc']:
+        if prev_level is None:
+            prev_level = level
+        elif prev_level == level - 1:
+        stack.append(stack[-1][-1][2])
+            prev_level = level
+        elif prev_level > level:
+            while prev_level > level:
+                if len(stack) > 1:
+                    stack.pop()
+                prev_level -= 1
+        stack[-1].append(TocEntry(anchor, title, []))
+
+    meta['toc'] = toc
+```
+---
+signature: meta, record
+---
+summary: This event is emitted after the markdown meta information is set.
+---
+type: event


### PR DESCRIPTION
Fixes #163 

Adds documentation for the rest of the Lektor plugin events.