### PR TITLE
Add a link from a plugin event to the plugin tag page for that event.

### DIFF
--- a/templates/doc-page.html
+++ b/templates/doc-page.html
@@ -52,6 +52,12 @@
       </ul>
 
       {{ this.body }}
+      {% if this.parent._slug == 'events' %}
+        <br>
+        <p>
+          <a href="{{ ('/plugins/tag/' ~ this._slug ~ '/')|url }}" class="ref">Plugins That Use This Event</a>
+        </p>
+      {% endif %}
 
       {% if this.version_history %}
       <div class="version-info version-info-collapsed">


### PR DESCRIPTION
Fixes #195 

Now it's easier to navigate back and forth from plugins, their tags, and the doc page for the plugins' events.