### PR TITLE
Fix repo link on Travis CI page so it works, and bump Python version

### DIFF
--- a/content/docs/deployment/travisci/contents.lr
+++ b/content/docs/deployment/travisci/contents.lr
@@ -24,7 +24,7 @@ file into your repository.  You can copy paste this over:
 
 ```yaml
 language: python
-python: 3.5
+python: 3.6
 install: "pip install Lektor"
 script: "lektor build"
 deploy:

--- a/content/docs/deployment/travisci/contents.lr
+++ b/content/docs/deployment/travisci/contents.lr
@@ -45,7 +45,7 @@ in the project file would be to use `ghpages+https` like this:
 
 ```ini
 [servers.ghpages]
-target = ghpages+https://username/repository.git
+target = ghpages+https://username/repository
 ```
 
 You need to add this to your `.lektorproject` file.


### PR DESCRIPTION
Fixes #238 

Fixes the repo link to remove an extraneous ``.git``  which breaks Travis deployment (as Lektor apparently adds it automatically), and also bump the Python version to something that isn't many years old. Separated into two commits for easy modification or dropping/reverting the latter change if required.

See issue for more details.

Thanks!