### PR TITLE
Add lektor-pythonmarkdown plugin page

### DIFF
--- a/content/plugins/lektor-pythonmarkdown/contents.lr
+++ b/content/plugins/lektor-pythonmarkdown/contents.lr
@@ -1,0 +1,13 @@
+name: lektor-pythonmarkdown
+---
+allow_comments: yes
+---
+categories: content
+---
+official: no
+---
+tags:
+
+markdown
+setup-env
+field type

--- a/content/plugins/lektor-rst/contents.lr
+++ b/content/plugins/lektor-rst/contents.lr
@@ -6,5 +6,5 @@ tags:
 
 rst
 reStructuredText
-field types
+field type
 setup-env


### PR DESCRIPTION
I've complete all my work and test on the pythonmarkdown plugin. It's ready for public ! So I want it to be shown on lektor website