### PR TITLE
fix: (:green_apple:) get it work for python 2.7.16

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -28,7 +28,10 @@ if 1:
     try:
         from urllib.request import urlopen
     except ImportError:
-        from urllib import urlopen
+        if sys.version_info[0] == 2 and sys.version_info[1] == 7 and sys.version_info[2] == 16:
+            from urllib2 import urlopen
+        else:
+            from urllib import urlopen
 
     PY2 = sys.version_info[0] == 2
     if PY2:


### PR DESCRIPTION
See https://github.com/lektor/lektor/issues/676, in python 2.7.16 it will throw 'No JSON object could be decoded'