### PR TITLE
Lektor plugin to compile css out of sass/scss

### DIFF
--- a/content/plugins/lektor-scss/contents.lr
+++ b/content/plugins/lektor-scss/contents.lr
@@ -1,0 +1,12 @@
+_model: plugin
+---
+name: lektor-scss
+---
+categories: build
+---
+tags:
+
+HTML
+scss
+sass
+after-build-all


### PR DESCRIPTION
I added a link to our lektor plugin which compiles
css out of scss/sass.