### PR TITLE
Update documentation of Guides:Portfolio size to width on some of the fields

### DIFF
--- a/content/docs/guides/portfolio/contents.lr
+++ b/content/docs/guides/portfolio/contents.lr
@@ -61,17 +61,17 @@ size = large
 [fields.date]
 label = Date
 type = date
-size = 1/4
+width = 1/4
 
 [fields.type]
 label = Project type
 type = string
-size = 1/4
+width = 1/4
 
 [fields.website]
 label = Website
 type = url
-size = 1/2
+width = 1/2
 
 [fields.description]
 label = Description


### PR DESCRIPTION
I changed the attribute of `size` to `width` when describing the width of a field. This is detailed in [https://www.getlektor.com/docs/models/](url) under the Fields heading.