### PR TITLE
fix markup for link: parentheses were swapped

### DIFF
--- a/content/docs/themes/installing/contents.lr
+++ b/content/docs/themes/installing/contents.lr
@@ -38,7 +38,7 @@ a particular theme.
 !!!! Not implemented yet.
 
 You could add the `themes` variable to the `.lektorproject` file and Lektor will
-search in the (community themes)[/themes] and automatically install it.
+search in the [community themes](/themes) and automatically install it.
 
 ```ini
 [project]


### PR DESCRIPTION
I think the parentheses were swapped, if I understand the intent correctly. Now it renders as "(community themes)[/themes]": https://www.getlektor.com/docs/themes/installing/