### PR TITLE
Unpin old version of readme_renderer

### DIFF
--- a/packages/project-data/setup.py
+++ b/packages/project-data/setup.py
@@ -9,7 +9,7 @@ setup(
     py_modules=['lektor_project_data'],
     install_requires=[
         'requests',
-        'readme_renderer[md]==24.0',
+        'readme_renderer[md]',
     ],
     entry_points={
         'lektor.plugins': [


### PR DESCRIPTION
Versions of `readme_renderer` older than the current version (28.0) fail when run under Python 3.9 (building the lektor site fails with `AttributeError: 'HTMLParser' object has no attribute 'unescape'`.)

I looked through the logs and didn't really see any notes as to why the version of `readme_renderer` was pinned, so I just removed the pin.  I've tested under Python 3.7, 3.8 and 3.9 and the site seem to build.