### PR TITLE
Omit leading `and` from plugin tag list if there is only one tag

### DIFF
--- a/templates/plugin.html
+++ b/templates/plugin.html
@@ -62,7 +62,7 @@
         </div>
         {% if this.tags %}
           {% for t in this.tags|sort %}
-            {{ "and " if loop.last }}
+            {{ "and " if loop.last and not loop.first }}
             <a href="{{ ('/plugins@tag/' ~ t ~ '/')|url }}">{{ t }}</a>{{ ", " if not loop.last }}
           {% endfor %}
         {% else %}


### PR DESCRIPTION
The title says it all.  If a plugin has just one tag, currently a spurious leading "and" is output in the tags list of the plugin page.