### PR TITLE
Fix typo: thumbnail arg `crop` must be set to a string

### DIFF
--- a/content/docs/api/db/record/thumbnail/contents.lr
+++ b/content/docs/api/db/record/thumbnail/contents.lr
@@ -8,7 +8,7 @@ signature: width=None, height=None, mode=None, upscale=None, quality=None
 ---
 body:
 
-!! From Lektor 2.0 to 3.1.2 cropping was set with `crop=True`. This is now deprecated and instead crop is an available mode, which can be set as `mode=crop`.
+!! From Lektor 2.0 to 3.1.2 cropping was set with `crop=True`. This is now deprecated and instead crop is an available mode, which can be set as `mode="crop"`.
 
 This method is available on attachments that are images and can be used to
 automatically generate a thumbnail.  The return value is a thumbnail proxy


### PR DESCRIPTION
Add quotes around `crop` in example `mode="crop"`.