### PR TITLE
updated installer.py to avoid installation failure on Elementary OS 5.1.7 Hera

### DIFF
--- a/assets/installer.py
+++ b/assets/installer.py
@@ -224,6 +224,8 @@ def install_lektor(lib_dir):
     create_virtualenv(lib_dir)
 
     pip = get_pip(lib_dir)
+    # avoid fail on Ubuntu,see https://github.com/lektor/lektor/issues/906
+    call([pip, "install", "--upgrade", "pip"])
 
     args = [pip, "install"]
     if IS_WIN:


### PR DESCRIPTION
Installation fails on Elementary OS 5.1.7 Hera with current installer.py, see discussion at [https://github.com/lektor/lektor/issues/906](https://github.com/lektor/lektor/issues/906)
Also fails on some other Debian-based distros. Implemented suggestion from @oliverbienert, i.e., adding a line in installer.py to upgrade pip before installing lektor. Works for me.




