### PR TITLE
add plugin lektor-image-resize

### DIFF
--- a/content/plugins/lektor-image-resize/contents.lr
+++ b/content/plugins/lektor-image-resize/contents.lr
@@ -1,0 +1,11 @@
+_model: plugin
+---
+name: lektor-image-resize
+---
+categories: templates
+---
+tags:
+
+webp
+images
+thumbnails


### PR DESCRIPTION
Add Plugin [lektor-image-resize](https://pypi.org/project/lektor-image-resize/), which will create jpg and webp images in the defined sizes using imagemagic.

It is very similar to the [lektor-thumbnail-generator](https://www.getlektor.com/plugins/lektor-thumbnail-generator/) plugin, but brings support for webp.