### PR TITLE
Normalize capitalization, punctuation and spelling of plugin tags, freshen event tags

### DIFF
--- a/content/plugins/lektor-markdown-header-anchors/contents.lr
+++ b/content/plugins/lektor-markdown-header-anchors/contents.lr
@@ -14,5 +14,5 @@ headers
 anchors
 table of contents
 markdown-config
-makrdown-meta-init
+markdown-meta-init
 markdown-meta-postprocess

--- a/content/plugins/lektor-minify/contents.lr
+++ b/content/plugins/lektor-minify/contents.lr
@@ -4,8 +4,8 @@ name: lektor-minify
 ---
 tags:
 
-django_htmlmin
-rCSSmin
+django-htmlmin
+RCSSmin
 rJSmin
 minify
 HTML

--- a/content/plugins/lektor-scss/contents.lr
+++ b/content/plugins/lektor-scss/contents.lr
@@ -9,4 +9,7 @@ tags:
 HTML
 SCSS
 Sass
-after-build-all
+before-build-all
+server-spawn
+server-stop
+

--- a/content/plugins/lektor-scss/contents.lr
+++ b/content/plugins/lektor-scss/contents.lr
@@ -7,6 +7,6 @@ categories: build
 tags:
 
 HTML
-scss
-sass
+SCSS
+Sass
 after-build-all

--- a/content/plugins/lektor-scsscompile/contents.lr
+++ b/content/plugins/lektor-scsscompile/contents.lr
@@ -7,7 +7,7 @@ categories: build
 tags:
 
 SCSS
-SASS
+Sass
 minify
 libsass
-before_build_all
+before-build-all

--- a/content/plugins/lektor-scsscompile/contents.lr
+++ b/content/plugins/lektor-scsscompile/contents.lr
@@ -11,3 +11,5 @@ Sass
 minify
 libsass
 before-build-all
+server-spawn
+server-stop

--- a/content/plugins/lektor-webpack-support/contents.lr
+++ b/content/plugins/lektor-webpack-support/contents.lr
@@ -13,7 +13,7 @@ webpack
 npm
 Yarn
 Node
-sCSS
+SCSS
 server-spawn
 server-stop
 before-build-all


### PR DESCRIPTION
This PR fixes a misspelling and normalizes the punctuation and capitalization of the tags of a few of the currently listed plugins.
This results in fewer duplicated tags in the tag index.

![image](https://user-images.githubusercontent.com/495018/151218102-2bfdab1f-74d3-4db3-831f-11062ffee3bf.png)

Also, while in there, I checked the current source for the plugins whose listings I modified, and updated the list plugin event tags (e.g. `before-build-all`) to match current reality.
