### PR TITLE
Publish to gh-pages

### DIFF
--- a/Website.lektorproject
+++ b/Website.lektorproject
@@ -6,13 +6,13 @@ url_style = relative
 [servers.ghpages]
 enabled = yes
 name = Github pages on repo
-target = ghpages://lektor/lektor-website
+target = ghpages://lektor/lektor-website?cname=www.getlektor.com
 default = yes
 
 [servers.ghpages-https]
 enabled = yes
 name = Github pages on repo
-target = ghpages+https://lektor/lektor-website
+target = ghpages+https://lektor/lektor-website?cname=www.getlektor.com
 default = not
 
 


### PR DESCRIPTION
This is a step on the road to fixing #330.

It adjusts the deploy.yml workflow to deploy to the `gh-pages` branch of this repository for publishing via Github Pages.

This also sets the gh-pages CNAME to `www.getlektor.com`.  _**As such, this PR should be merged roughly simultaneously with the required DNS updates for `www.getlektor.com`**_.  (When a CNAME is set for a gh-pages site, requests to the non-custom domain, e.g. `https://lektor.github.io/lektor-website/` get redirected to the custom domain name.  As well, without the CNAME, Github can not automatically construct an SSL certificate for the site.)

Instructions for the required DNS configuration are [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).

If, @mitsuhiko is happy to have the pocoo.org server provide the redirect from getlektor.com to www.getlektor.com, all that is really required is to create a CNAME:
```
    www.getlektor.com. CNAME lektor.github.io.
```
(To have github provide the redirect from getlektor.com to www.getlektor.com, then `A` and `AAAA` records need to be placed at `getlektor.com.`.)

----

ETA: I've now merged most of what was in this PR into `master`, so that currently the `deploy.yml` workflow is deploying the `master` branch to https://lektor.github.io/lektor-website/.

The only bit left in this PR is to create the CNAME file in the `gh-pages` branch.  (Once that's done, `lektor.github.io` will start redirecting all requests to `www.getlektor.com`, so, to avoid hiding the ghpages content, we're avoiding doing that until we're about ready to update the DNS records to point www.getlektor.com to github pages.) 