### PR TITLE
Fix a number of broken and stale links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,12 +12,19 @@ on:
   schedule:
     - cron: '23 2 * * *'
 
+env:
+  DEPLOY: >-
+    ${{
+    github.event_name != 'pull_request'
+    &&
+    github.ref == 'refs/heads/master'
+    }}
+  OUTPUT: _html
+
 jobs:
-  deploy-lektor-website:
-    name: Deploy lektor website
+  build:
+    name: Build lektor website
     runs-on: ubuntu-latest
-    env:
-      DEPLOY: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v2
 
@@ -28,10 +35,20 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install lektor
 
-      - run: lektor build
+      - name: Build lektor website
+        run: lektor build -O '${{ env.OUTPUT }}'
 
-      - run: lektor deploy ghpages-https
+      - name: Check for broken internal links
+        uses: wjdp/htmltest-action@master
+        with:
+          path: ${{ env.OUTPUT }}
+          config: .htmltest.yml
+          skip_external: true
+          log_level: 1
+
+      - name: Deploy lektor website
         if: env.DEPLOY == 'true'
+        run: lektor deploy -O '${{ env.OUTPUT }}' ghpages-https
         env:
           LEKTOR_DEPLOY_USERNAME: lektor
           LEKTOR_DEPLOY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,8 @@
+IgnoreAltMissing: true
+IgnoreURLs:
+  - "^http://localhost:"
+
+# htmltest does not like quotes around URL in meta refresh
+CheckMetaRefresh: false
+# our redirect page doesn't have a doctype
+CheckDoctype: false

--- a/content/blog/lektor-at-rails-girls-summer-of-code/contents.lr
+++ b/content/blog/lektor-at-rails-girls-summer-of-code/contents.lr
@@ -32,9 +32,9 @@ website:
 > stipend, from July-September, to work on Open Source projects of their
 > choice.
 
-Lektor was accepted as a particpating project.  For more information about
+Lektor was accepted as a participating project.  For more information about
 the project there refer to the [project overview on
-RGSOC](https://teams.railsgirlssummerofcode.org/projects/115-lektor-cms).
+RGSOC :ext](https://railsgirlssummerofcode.org/blog/page/36/).
 
 We want to make it as easy as possible to work on Lektor during the event which
 is why we will be very flexible with regards to which area interested
@@ -44,3 +44,5 @@ If you are interested in working on Lektor you can reach out to us via
 Twitter at [@getlektor](https://twitter.com/getlektor) or
 <a href="https://gitter.im/lektor/lektor"
 class="js-gitter-toggle-chat-button">Gitter</a>.
+----
+class: default

--- a/content/blog/plugin-play/contents.lr
+++ b/content/blog/plugin-play/contents.lr
@@ -37,6 +37,6 @@ Plugins are tagged with specific key words or phrases that describe what they ar
 
 I think this is especially useful for plugin development when the tag is an event that the plugin hooks. This allows you to quickly find the source code of plugins that depend on the same Lektor plugin events, so that you can see many quick examples to help you write your own plugin. For instance, you can find all of the plugins that hook the `before-build-all` event by looking at it's tag page [here](/plugins/tag/before-build-all/). Tag pages for events also have links back to the plugin documentation pages, including the page for that specific event.
 
-Now go check out some [plugins](/plugins)! 
+Now go check out some [plugins](/plugins/)! 
 ----
 class: default

--- a/content/docs/api/db/asset/children/contents.lr
+++ b/content/docs/api/db/asset/children/contents.lr
@@ -1,0 +1,11 @@
+title: children
+---
+summary: Returns a query to the children of a page.
+---
+type: property
+---
+body:
+
+[Assets :ref](../) that correspond to directories can have children
+below them.  The `children` attribute provides a convenient way to access
+those. It returns an iterable of child assets.

--- a/content/docs/api/db/asset/contents.lr
+++ b/content/docs/api/db/asset/contents.lr
@@ -1,0 +1,14 @@
+title: Asset
+---
+summary: Static assets, copied verbatim to the output.
+---
+module: lektor.assets
+---
+type: class
+---
+body:
+
+Assets are [Source Objects :ref](../obj/) that correspond to static files that
+are copied verbatim from the `/assets` folder to the output directory.
+
+Usually, there is no need to manipulate Asset objects directly.

--- a/content/docs/api/db/asset/get-child/contents.lr
+++ b/content/docs/api/db/asset/get-child/contents.lr
@@ -1,0 +1,13 @@
+title: get_child
+---
+body:
+
+Lookup a child of the asset.  Returns `None` if no child exists with the specified name.
+
+Naturally, this method always returns `None` unless the asset is a directory.
+---
+signature: name, from_url=False
+---
+summary: Get child asset
+---
+type: method

--- a/content/docs/api/db/expression/contents.lr
+++ b/content/docs/api/db/expression/contents.lr
@@ -17,7 +17,7 @@ of it can create more expressive expressions.  `F.name` literally just means
 that a field by that name exists and is set to a value.
 
 The query syntax is mostly the same in Python as well as in the Jinja 2
-templates, the main difference are [and :ref](../and/) and [or :ref](../or/).
+templates, the main difference are [and :ref](and/) and [or :ref](or/).
 
 ## Example
 

--- a/content/docs/api/db/obj/url-to/contents.lr
+++ b/content/docs/api/db/obj/url-to/contents.lr
@@ -20,7 +20,7 @@ relative to the current page and `external` can be used to also add the
 domain part to the URL (if configured).  The default behavior is to use the
 configured URL style (which is `relative`) unless absolute or external were
 explicitly provided.  For more information read about this in the
-[Project Configuration :ref](../../../../project/file/#[project]).
+[Project Configuration :ref](../../../../project/file/#project).
 
 ## Example
 

--- a/content/docs/api/environment/jinja-env/contents.lr
+++ b/content/docs/api/environment/jinja-env/contents.lr
@@ -7,7 +7,7 @@ summary: The configured Jinja 2 Environment.
 body:
 
 This object is a configured Jinja2 environment.  For more information you can
-refer to the [Jinja 2 Documentation :ref](http://jinja.pocoo.org/docs/dev/api/#jinja2.Environment).
+refer to the [Jinja 2 Documentation :ext](https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment).
 
 This is where plugins can inject additional data like custom filters, tests
 or global functions.

--- a/content/docs/api/environment/render-template/contents.lr
+++ b/content/docs/api/environment/render-template/contents.lr
@@ -14,7 +14,7 @@ method.  Here are the parameters and what they mean:
 * `name`: this is the name of the template that should be rendered.  It's
   the local filename relative to the `templates` folder and uses slashes
   for paths.
-* `pad`: when a [Pad :ref](../../pad/) is available, it should be provided
+* `pad`: when a [Pad :ref](../../db/pad/) is available, it should be provided
   so that the `site` variable can be populated.  If a context is available
   then the pad will also be pulled from the context if needed.
 * `this`: the value of the `this` variable in templates.  This should always

--- a/content/docs/api/publisher/publish/contents.lr
+++ b/content/docs/api/publisher/publish/contents.lr
@@ -20,7 +20,7 @@ The parameters to the function are as follows:
 
 * `target_url`: a URL object with the parsed URL.  This object comes from the
   Werkzeug library and gives access to the individual parts of a URL by the
-  exposed attributes ([Read about the URL object :ext](http://werkzeug.pocoo.org/docs/0.11/urls/)).
+  exposed attributes ([Read about the URL object :ext](https://werkzeug.palletsprojects.com/en/2.0.x/urls/)).
 * `credentials`: an optional dictionary with command line supplied credentials.
   Note that these credentials might be completely absent and the keys which are
   provided might change with future versions of Lektor.

--- a/content/docs/api/templates/filters/contents.lr
+++ b/content/docs/api/templates/filters/contents.lr
@@ -5,4 +5,4 @@ summary: Filters specific to Lektor that templates have access to.
 body:
 
 These is the list of custom filters added by Lektor in addition to the
-[built in filters :ext](http://jinja.pocoo.org/docs/dev/templates/#builtin-filters).
+[built in filters :ext](https://jinja.palletsprojects.com/en/3.0.x/templates/#list-of-builtin-filters).

--- a/content/docs/api/templates/globals/get-random-id/contents.lr
+++ b/content/docs/api/templates/globals/get-random-id/contents.lr
@@ -10,7 +10,7 @@ body:
 
 In some situations it can be very useful to generate a unique ID in templates.
 This is particularly useful when creating templates for the [Flow
-:ref](../../../../flow/) system and you need unique IDs for the DOM.
+:ref](../../../../content/flow/) system and you need unique IDs for the DOM.
 
 ## Example
 

--- a/content/docs/api/utils/process-image/contents.lr
+++ b/content/docs/api/utils/process-image/contents.lr
@@ -18,7 +18,7 @@ width and/or height, and the operation mode.
 In the default mode, if width or height are `None`, they are calculated
 from the source image's dimensions so that the image is scaled proportionally.
 
-Used internally for the implementation of [thumbnail :ref](../../db/record/thumbnail), and exposed as an API for image-processing plugins.
+Used internally for the implementation of [thumbnail :ref](../../db/record/thumbnail/), and exposed as an API for image-processing plugins.
 
 ## Example
 

--- a/content/docs/content/urls/contents.lr
+++ b/content/docs/content/urls/contents.lr
@@ -103,7 +103,7 @@ to be configured.
 
 You can pick the default for URL generation in the project configuration.
 For more information read about the [Project Configuration
-:ref](../../project/file/#[project]).
+:ref](../../project/file/#project).
 
 The default of `relative`, a relative URL style, means that you can deploy a
 website to a sub folder without any configuration, however most likely custom

--- a/content/docs/deployment/glpages/contents.lr
+++ b/content/docs/deployment/glpages/contents.lr
@@ -5,7 +5,7 @@ summary: Deploys to GitLab Pages.
 body:
 
 [GitLab](https://gitlab.com/) supports Lektor on their [GitLab
-Pages](http://doc.gitlab.com/ee/pages/) infrastructure.  Effectively
+Pages](https://docs.gitlab.com/ee/user/project/pages/) infrastructure.  Effectively
 GitLab can build your website out of any repository on GitLab and hosts it
 up on either a subdomain or a custom domain (including SSL).
 
@@ -90,7 +90,7 @@ pages:
 If you want to use a [CNAME :ext](https://en.wikipedia.org/wiki/CNAME) with
 GitLab pages you can configure it in the GitLab settings:
 
-* [Configure CNAME](http://doc.gitlab.com/ee/pages/#add-a-custom-domain-to-your-pages-website)
+* [Configure CNAME](https://docs.gitlab.com/ee/user/project/pages/custom_domains_ssl_tls_certification/#set-up-pages-with-a-custom-domain)
 
 ## SSL/TLS Support
 
@@ -98,7 +98,7 @@ If you have an SSL certificate and a custom domain, you can upload your private
 key and certificate to GitLab and SSL will become available on your custom
 domain as well.
 
-* [Configure SSL/TLS](http://doc.gitlab.com/ee/pages/#secure-your-custom-domain-website-with-tls)
+* [Configure SSL/TLS](https://docs.gitlab.com/ee/user/project/pages/custom_domains_ssl_tls_certification/#adding-an-ssltls-certificate-to-pages)
 
 ## 404 Pages
 

--- a/content/docs/guides/sitemap/contents.lr
+++ b/content/docs/guides/sitemap/contents.lr
@@ -51,7 +51,7 @@ from the last build.
 Note that because sitemaps need to have external URLs (with scheme and
 everything) you will need to configure the `url` of the site before the
 template starts working.  For more information see [Project File
-:ref](../../project/file/#[project])
+:ref](../../project/file/#project)
 
 ## Human Readable Sitemap
 

--- a/content/docs/plugins/dev/contents.lr
+++ b/content/docs/plugins/dev/contents.lr
@@ -81,7 +81,7 @@ So going line by line, these are what the things mean:
   is your plugin name with underscores instead of dashes as separators.
   If you need more than one module you should use a package instead.  This is
   not covered here, but you can find this in the [setuptools documentation
-  :ext](https://pythonhosted.org/setuptools/).
+  :ext](https://setuptools.pypa.io/en/latest/).
 * `entry_points`: this is meta data that is needed to associate our package
   with Lektor.  Lektor will load all plugins in the `lektor.plugins` list.
   It can be a list of definitions in the form `plugin-name = import_path`.

--- a/content/docs/plugins/howto/contents.lr
+++ b/content/docs/plugins/howto/contents.lr
@@ -117,7 +117,7 @@ function we also track the plugin's filename to rebuild if the plugin changes.
 Let's say you want to add an "asciidoc"
 [field type :ref](../../api/db/types/) so you can write with [AsciiDoc](http://www.methods.co.nz/asciidoc) markup.
 
-First [install AsciiDoc](http://www.methods.co.nz/asciidoc/INSTALL.html) so its command-line program is available. Then update `blog-post.ini` from the [blog guide :ref](../../guides/blog) like so:
+First [install AsciiDoc](http://www.methods.co.nz/asciidoc/INSTALL.html) so its command-line program is available. Then update `blog-post.ini` from the [blog guide :ref](../../guides/blog/) like so:
 
 ```ini
 [fields.body]

--- a/content/docs/plugins/publishing/contents.lr
+++ b/content/docs/plugins/publishing/contents.lr
@@ -86,7 +86,7 @@ credentials for `pypi`.  Next time it will have remembered them.
 
 ### Guide
 
-We'd love to see your new plugin listed on [our plugins page  :ref](/plugins). To do that, submit a pull request to [this repository :ext](https://github.com/lektor/lektor-website) that adds your plugin as a sub-page of /plugins. To have your plugin page look it's best and be found more easily here and on [PyPI :ext](https://pypi.org/), please [fill out your setup.py :ext](https://packaging.python.org/tutorials/distributing-packages/) completely (as in [the above snippet :ref](/docs/plugins/publishing/#enhance-your-setup.py)), including
+We'd love to see your new plugin listed on [our plugins page  :ref](/plugins/). To do that, submit a pull request to [this repository :ext](https://github.com/lektor/lektor-website) that adds your plugin as a sub-page of /plugins. To have your plugin page look it's best and be found more easily here and on [PyPI :ext](https://pypi.org/), please [fill out your setup.py :ext](https://packaging.python.org/tutorials/distributing-packages/) completely (as in [the above snippet :ref](/docs/plugins/publishing/#enhance-your-setup.py)), including
 
 * `author` and `author_email`
 * `classifiers`, (optional) such as

--- a/content/docs/quickstart/contents.lr
+++ b/content/docs/quickstart/contents.lr
@@ -12,7 +12,7 @@ the command line client which is the recommended way to do development until
 the website is ready for end user management.
 
 If you do not have the `lektor` [command line executable :ref](../cli/)
-available yet just consult the [Installation :ref](../installation) section of
+available yet just consult the [Installation :ref](../installation/) section of
 the documentation.
 
 ## Creating a New Project

--- a/content/docs/templates/videoops/contents.lr
+++ b/content/docs/templates/videoops/contents.lr
@@ -14,7 +14,7 @@ Just like [images](../imageops/), videos are separate files that are embedded in
 {% endfor %}
 ```
 
-Just like images you can also access them using `site.get('/myfolder').attachments.videos` or `site.get('/myfolder').attachments.get('examplevideo.mp4')`. Note that not all formats are detected as videos (see [attachments](../../content/attachments/)). If your format is not in the list you may still be able to get it detected as a video by adding it to your [Lektor project file](../../project/file/#[attachment_types]).
+Just like images you can also access them using `site.get('/myfolder').attachments.videos` or `site.get('/myfolder').attachments.get('examplevideo.mp4')`. Note that not all formats are detected as videos (see [attachments](../../content/attachments/)). If your format is not in the list you may still be able to get it detected as a video by adding it to your [Lektor project file](../../project/file/#attachment-types).
 
 
 ## Accessing metadata

--- a/content/docs/themes/installing/contents.lr
+++ b/content/docs/themes/installing/contents.lr
@@ -38,7 +38,7 @@ a particular theme.
 !!!! Not implemented yet.
 
 You could add the `themes` variable to the `.lektorproject` file and Lektor will
-search in the [community themes](/themes) and automatically install it.
+search in the [community themes](/themes/) and automatically install it.
 
 ```ini
 [project]

--- a/content/docs/themes/installing/contents.lr
+++ b/content/docs/themes/installing/contents.lr
@@ -38,7 +38,10 @@ a particular theme.
 !!!! Not implemented yet.
 
 You could add the `themes` variable to the `.lektorproject` file and Lektor will
-search in the [community themes](/themes/) and automatically install it.
+search in the
+<!-- FIXME: use this link when theme showcase exists [community themes](/themes/) -->
+[community themes :ext](https://github.com/lektor/lektor-themes)
+and automatically install it.
 
 ```ini
 [project]

--- a/content/docs/themes/packages/contents.lr
+++ b/content/docs/themes/packages/contents.lr
@@ -8,7 +8,7 @@ body:
 
 !!!! Not implemented yet.
 
-Themes could depend on [plugins](../../plugins), and they will be loaded along
+Themes could depend on [plugins](../../plugins/), and they will be loaded along
 the theme.
 
 1. You could use the `[packages]` section of the `theme.ini` to install

--- a/content/plugin-categories/templates/contents.lr
+++ b/content/plugin-categories/templates/contents.lr
@@ -1,7 +1,7 @@
 body:
 
 #### text-block ####
-text: These plugins primarily deal with Lektor's [Templates :ref](/docs/templates/). They may add or modify [context :ref](docs/templates/#template-context), [api :ref](/docs/api/templates/), [filters :ref](/docs/api/templates/filters/), [globals :ref](/docs/api/templates/globals/), [modify images :ref](/docs/templates/imageops/), [change navigation :ref](/docs/templates/navigation/), or many other functionalities available to templates.
+text: These plugins primarily deal with Lektor's [Templates :ref](/docs/templates/). They may add or modify [context :ref](/docs/templates/#template-context), [api :ref](/docs/api/templates/), [filters :ref](/docs/api/templates/filters/), [globals :ref](/docs/api/templates/globals/), [modify images :ref](/docs/templates/imageops/), [change navigation :ref](/docs/templates/navigation/), or many other functionalities available to templates.
 ----
 class: default
 ---

--- a/content/plugins/contents.lr
+++ b/content/plugins/contents.lr
@@ -9,7 +9,7 @@ text:
 
 Lektor is a young project but it has a growing list of both official and community supported plugins. Official plugins are maintained by Lektor and kept in good shape together with the rest of the project. Community plugins are moderated and updated regularly, but they might not keep pace with development on Lektor. They are maintained by the community. Install them with `lektor plugins add NAME`.
 
-If you want to make or publish your own plugin, or see our [docs :ref](/docs/plugins).
+If you want to make or publish your own plugin, or see our [docs :ref](/docs/plugins/).
 
 (*) Asterisks denote official plugins.
 ----

--- a/databags/menu.ini
+++ b/databags/menu.ini
@@ -1,27 +1,27 @@
 [download]
-path = /downloads
+path = /downloads/
 label = Download
 
 [docs]
-path = /docs
+path = /docs/
 label = Documentation
 
 [poweredby]
-path = /showcase
+path = /showcase/
 label = Showcase
 
 [plugins]
-path = /plugins
+path = /plugins/
 label = Plugins
 
 # [themes]
-# path = /themes
+# path = /themes/
 # label = Themes
 
 [community]
-path = /community
+path = /community/
 label = Community
 
 [blog]
-path = /blog
+path = /blog/
 label = Blog

--- a/templates/blog-archive/index.html
+++ b/templates/blog-archive/index.html
@@ -3,7 +3,7 @@
 {% block blog_body %}
   <h1>The Transcript Archive</h1>
   <p>
-    <a href="{{ '/blog'|url }}">&laquo; back to the blog</a>
+    <a href="{{ '/blog/'|url }}">&laquo; back to the blog</a>
   <p>
     There have been posts in the following years:
   <ul>

--- a/templates/doc-page.html
+++ b/templates/doc-page.html
@@ -53,10 +53,13 @@
 
       {{ this.body }}
       {% if this.parent._slug == 'events' %}
-        <br>
-        <p>
-          <a href="{{ ('/plugins/tag/' ~ this._slug ~ '/')|url }}" class="ref">Plugins That Use This Event</a>
-        </p>
+        {% if this._slug in site.query('/plugins').distinct('tags') %}
+          <br>
+          <p>
+            A list of some plugins that make use of this event is available
+            <a href="{{ ('/plugins/tag/' ~ this._slug ~ '/')|url }}" class="ref">here</a>.
+          </p>
+        {% endif %}
       {% endif %}
 
       {% if this.version_history %}

--- a/templates/doc-page.html
+++ b/templates/doc-page.html
@@ -43,7 +43,7 @@
       {% endif %}
       {% if this.template_var %}
         <li>Template variable: <a href="{{ (
-          '/docs/api/templates/globals/' ~ this.template_var|lower ~ '/')|url
+          '/docs/api/templates/globals/' ~ this.template_var|lower|replace('_', '-') ~ '/')|url
           }}"><code>{{ this.template_var }}</code></a></li>
       {% endif %}
       {% if this.version_added %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -68,8 +68,8 @@
           {%- endif %}
         </div>
         <div class="col-sm-8">
-          <a href="{{ '/license'|url }}">License & Copyright</a> •
-          <a href="{{ '/contact'|url }}">Contact</a> •
+          <a href="{{ '/license/'|url }}">License & Copyright</a> •
+          <a href="{{ '/contact/'|url }}">Contact</a> •
           Made with <i class="fa fa-fw fa-heart" title="Heart"><span hidden>Heart</span></i> in Carinthia
         </div>
       </div>

--- a/templates/plugin-tag.html
+++ b/templates/plugin-tag.html
@@ -12,11 +12,11 @@
         Take a look at their source code to see how they work!
       </p>
       <p>
-        <a href="{{ '/docs/plugins'|url }}" class="ref">Intro to Plugins</a>
+        <a href="{{ '/docs/plugins/'|url }}" class="ref">Intro to Plugins</a>
         ||
         <a href="{{ '/docs/cli/plugins/'|url }}" class="ref">Plugin Commands</a>
         ||
-        <a href="{{ '/docs/api/plugins'|url }}" class="ref">Plugin API</a>
+        <a href="{{ '/docs/api/plugins/'|url }}" class="ref">Plugin API</a>
         ||
         <a href="{{ event|url }}" class="ref">This Event</a>
       </p>
@@ -30,6 +30,6 @@
   </div>
 
   <p>View a list of all Lektor plugin tags
-    <a href="{{ '/plugins/tags'|url }}" class="ref">here</a>.
+    <a href="{{ '/plugins/tags/'|url }}" class="ref">here</a>.
   </p>
 {% endblock %}

--- a/templates/plugin.html
+++ b/templates/plugin.html
@@ -69,7 +69,7 @@
           <p>Plugin has no tags.</p>
         {% endif %}
         <p>
-          View <a href="{{ '/plugins/tags'|url }}" class="ref">all tags</a>.
+          View <a href="{{ '/plugins/tags/'|url }}" class="ref">all tags</a>.
         </p>
       </div>
 

--- a/templates/plugins.html
+++ b/templates/plugins.html
@@ -27,6 +27,6 @@
     Plugins are also tagged with keywords and topics.
     Their tags are listed on their page and are navigable.
     You can view a list of all of the tags
-    <a href="{{ '/plugins/tags'|url }}" class="ref">here</a>.
+    <a href="{{ '/plugins/tags/'|url }}" class="ref">here</a>.
   </p>
 {% endblock %}


### PR DESCRIPTION
I ran the [htmltest](https://github.com/wjdp/htmltest) link checker on the site and discovered a number of broken and stale links.

In this PR:
- Fix all broken internal links (at least all internal links flagged by `htmltest`.)
- Adds trailing slashes on a number of internal links.  (While not strictly required, this does minimize redirects.)
- Fix a few stale external links.
- Fix a few miscellaneous other typos noticed along the way.
- Add a test for broken internal links to the CI workflow.
