### PR TITLE
Document use of SingleInputType base class

### DIFF
--- a/content/docs/api/db/type/contents.lr
+++ b/content/docs/api/db/type/contents.lr
@@ -28,9 +28,9 @@ needs to be called `MyThingType`.  Afterwards you can register it with the
 environment in [setup_env :ref](../../plugins/events/setup-env/):
 
 ```python
-from lektor.types import Type
+from lektor.types.primitives import SingleInputType
 
-class MyThingType(Type):
+class MyThingType(SingleInputType):
     widget = 'singleline-text'
 
     def value_from_raw(self, raw):
@@ -39,6 +39,11 @@ class MyThingType(Type):
 def setup_env(self, **extra):
     self.env.add_type(MyThingType)
 ```
+
+!!! In the above example, the new type declares a base class of `SingleInputType`.
+    This is appropriate for types that use a single-line input widget in the admin UI —
+    it enables the use of the `addon_label` [field option :ref](/docs/models/#fields).
+    Custom types that use more general input types should instead inherit from `lektor.types.base.Type`.
 
 For more information see [value_from_raw :ref](value-from-raw/).
 

--- a/content/docs/plugins/howto/contents.lr
+++ b/content/docs/plugins/howto/contents.lr
@@ -187,3 +187,8 @@ class AsciiDocPlugin(Plugin):
         # Derives type name "asciidoc" from class name.
         self.env.add_type(AsciiDocType)
 ```
+
+### Base Classes
+
+In the general case, new types should inherit from `lektor.types.base.Type`.
+However, when creating a new type that will use a "single-line" input widget in the Admin GUI, inheriting from `lektor.types.primitives.SingleInputType` will enable the use of the `addon_label` [field option :ref](/docs/models/#fields).


### PR DESCRIPTION
Document that if one wants the `addon_label` *field option* to work with their custom single-line type, it should inherit from `lektor.types.primitives.SingleInputType` rather than directly from `lektor.types.base.Type`.  (See lektor/lektor#1089.)

Fixes #357.
