### PR TITLE
Note that --output-path CLI param is relative to cwd

### DIFF
--- a/content/docs/cli/build/contents.lr
+++ b/content/docs/cli/build/contents.lr
@@ -30,6 +30,8 @@ used by external scripts to only deploy on successful build for instance.
 ## Options
 
 - `-O, --output-path PATH`: The output path.
+   This overrides any `output_path` setting in the [project file :ref](http://localhost:5000/docs/project/file/#project).
+   A relative path is interpreted relative to the *current working directory*.
 - `--watch`: If this is enabled the build process goes into an automatic
   loop where it watches the file system for changes and rebuilds.
 - `--prune / --no-prune`: Controls if old artifacts should be pruned.

--- a/content/docs/cli/clean/contents.lr
+++ b/content/docs/cli/clean/contents.lr
@@ -18,6 +18,8 @@ in the Lektor cache is used.
 ## Options
 
 - `-O, --output-path PATH`: The output path.
+   This overrides any `output_path` setting in the [project file :ref](http://localhost:5000/docs/project/file/#project).
+   A relative path is interpreted relative to the *current working directory*.
 - `-v, --verbose`: Increases the verbosity of the logging.
 - `--yes`: Confirms the cleaning.
 - `--help`: print this help page.

--- a/content/docs/cli/deploy/contents.lr
+++ b/content/docs/cli/deploy/contents.lr
@@ -27,6 +27,8 @@ For more information see the deployment chapter in the documentation.
 ## Options
 
 - `-O, --output-path PATH`: The output path.
+   This overrides any `output_path` setting in the [project file :ref](http://localhost:5000/docs/project/file/#project).
+   A relative path is interpreted relative to the *current working directory*.
 - `--username TEXT`: An optional username to override the URL.
 - `--password TEXT`: An optional password to override the URL or the
   default prompt.

--- a/content/docs/cli/server/contents.lr
+++ b/content/docs/cli/server/contents.lr
@@ -25,6 +25,10 @@ HTTP server.
 - `-p, --port INTEGER`: The port to bind to.
 - `-O, --output-path PATH`: The dev server will build into the same folder
   as the build command by default.
+- `-O, --output-path PATH`: The output path.
+   Note that, by default, the dev server will build into the same folder as the build command.
+   This overrides any `output_path` setting in the [project file :ref](http://localhost:5000/docs/project/file/#project).
+   A relative path is interpreted relative to the *current working directory*.
 - `-v, --verbose`: Increases the verbosity of the logging.
 - `-f, --build-flag TEXT`: Defines an arbitrary build flag.  These can be
   used by plugins to customize the build process.  More information can be


### PR DESCRIPTION
This updates the docs for lektor/lektor#1120.

Namely, it adds verbiage to say that `--output-path` is (now) interpreted relative to the current working directory.