### PR TITLE
Add plugin: lektor-redirect

### DIFF
--- a/content/plugins/lektor-redirect/contents.lr
+++ b/content/plugins/lektor-redirect/contents.lr
@@ -1,0 +1,10 @@
+_model: plugin
+---
+name: lektor-redirect
+---
+categories: build
+---
+tags:
+
+setup-env
+before-build-all


### PR DESCRIPTION
Add a new plugin to the plugin list.

[Lektor-redirect](https://github.com/dairiki/lektor-redirect/) helps with generating redirects, e.g. for pages that have been moved with the Lektor site.