### PR TITLE
Install imagemagick in runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,11 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install lektor
 
+      - name: Install Imagemagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
+
       - name: Build lektor website
         run: lektor build -f webpack -O '${{ env.OUTPUT }}'
 


### PR DESCRIPTION
The `ubuntu-latest` is moving from `ubuntu-22.04` to `ubuntu-24.04` (actions/runner-images#10636).  22.04 had imagemagick pre-installed. 24.04 does not.
